### PR TITLE
Images compatible with new sidecar

### DIFF
--- a/.github/workflows/atlas.yaml
+++ b/.github/workflows/atlas.yaml
@@ -1,4 +1,4 @@
-name: Builds perfsonar pull collector image
+name: Builds ATLAS xAOD images
 
 on:
   push:
@@ -37,18 +37,3 @@ jobs:
           push: true
           build-args: ANALYSISBASE_TAG=22.2.107
           tags: ivukotic/servicex_func_adl_xaod_transformer:22.2.107
-
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: CMS_AOD
-          push: true
-          tags: ivukotic/servicex_func_adl_cms_aod_transformer:cmssw-5-3-32
-
-  
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: uproot
-          push: true
-          tags: ivukotic/servicex_func_adl_uproot_transformer:uproot4 

--- a/.github/workflows/atlas.yaml
+++ b/.github/workflows/atlas.yaml
@@ -1,9 +1,11 @@
 name: Builds ATLAS xAOD images
-
+# These actions need some more work. It would be good to parameterize
+# the Atlas Analysis Base version, and to have a way to build the
+# images to specific versions
 on:
   push:
     branches:
-      - "ilija"
+      - "disabled"
 
 jobs:
   docker:
@@ -28,7 +30,7 @@ jobs:
           context: ATLASxAOD
           push: true
           build-args: ANALYSISBASE_TAG=21.2.231 
-          tags: ivukotic/servicex_func_adl_xaod_transformer:21.2.231
+          tags: sslhep/servicex_func_adl_xaod_transformer:21.2.231
       
       - name: Build and push
         uses: docker/build-push-action@v3
@@ -36,4 +38,4 @@ jobs:
           context: ATLASxAOD
           push: true
           build-args: ANALYSISBASE_TAG=22.2.107
-          tags: ivukotic/servicex_func_adl_xaod_transformer:22.2.107
+          tags: sslhep/servicex_func_adl_xaod_transformer:22.2.107

--- a/.github/workflows/cms.yaml
+++ b/.github/workflows/cms.yaml
@@ -1,9 +1,12 @@
 name: Builds CMS AOD images
+# These actions need some more work. It would be good to parameterize
+# the CMS Base version, and to have a way to build the
+# images to specific versions
 
 on:
   push:
     branches:
-      - "ilija"
+      - "disabled"
 
 jobs:
   docker:

--- a/.github/workflows/cms.yaml
+++ b/.github/workflows/cms.yaml
@@ -1,4 +1,4 @@
-name: Builds Uproot image
+name: Builds CMS AOD images
 
 on:
   push:
@@ -25,6 +25,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          context: uproot
+          context: CMS_AOD
           push: true
-          tags: ivukotic/servicex_func_adl_uproot_transformer:uproot4 
+          tags: ivukotic/servicex_func_adl_cms_aod_transformer:cmssw-5-3-32

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
           image: ivukotic/servicex_func_adl_xaod_transformer
           tags: latest, ${{ github.sha }}
           registry: docker.io
-          dockerfile: ATLASxAOD/Dockerfile
+          directory: ATLASxAOD
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,24 @@
+name: Builds perfsonar pull collector image
+
+on:
+  push:
+    branches:
+      - "ilija"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.2
+
+      - name: Docker Build & Push Action
+        uses: mr-smithers-excellent/docker-build-push@v6.2
+        with:
+          image: ivukotic/servicex_func_adl_xaod_transformer
+          tags: latest, ${{ github.sha }}
+          registry: docker.io
+          dockerfile: ATLASxAOD/Dockerfile
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,9 +21,34 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: ATLASxAOD
           push: true
-          tags: ivukotic/servicex_func_adl_xaod_transformer:latest
+          build-args: ANALYSISBASE_TAG=21.2.231 
+          tags: ivukotic/servicex_func_adl_xaod_transformer:21.2.231
+      
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ATLASxAOD
+          push: true
+          build-args: ANALYSISBASE_TAG=22.2.107
+          tags: ivukotic/servicex_func_adl_xaod_transformer:22.2.107
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: CMS_AOD
+          push: true
+          tags: ivukotic/servicex_func_adl_cms_aod_transformer:cmssw-5-3-32
+
+  
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: uproot
+          push: true
+          tags: ivukotic/servicex_func_adl_uproot_transformer:uproot4 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,13 +12,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.5.2
 
-      - name: Docker Build & Push Action
-        uses: mr-smithers-excellent/docker-build-push@v6.2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
-          image: ivukotic/servicex_func_adl_xaod_transformer
-          tags: latest, ${{ github.sha }}
-          registry: docker.io
-          directory: ATLASxAOD
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ATLASxAOD
+          push: true
+          tags: ivukotic/servicex_func_adl_xaod_transformer:latest

--- a/.github/workflows/uproot.yaml
+++ b/.github/workflows/uproot.yaml
@@ -1,9 +1,10 @@
 name: Builds Uproot image
+# These actions need some more work.
 
 on:
   push:
     branches:
-      - "ilija"
+      - "disabled"
 
 jobs:
   docker:

--- a/.github/workflows/uproot.yaml
+++ b/.github/workflows/uproot.yaml
@@ -1,0 +1,30 @@
+name: Builds perfsonar pull collector image
+
+on:
+  push:
+    branches:
+      - "ilija"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: uproot
+          push: true
+          tags: ivukotic/servicex_func_adl_uproot_transformer:uproot4 

--- a/ATLASxAOD/Dockerfile
+++ b/ATLASxAOD/Dockerfile
@@ -6,7 +6,7 @@ USER root
 
 RUN yum clean all
 RUN yum -y update
-RUN yum -y install nc
+RUN yum -y install nc jq
 
 RUN yum install -y https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-latest.rpm
 RUN curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg

--- a/ATLASxAOD/Dockerfile
+++ b/ATLASxAOD/Dockerfile
@@ -6,6 +6,7 @@ USER root
 
 RUN yum clean all
 RUN yum -y update
+RUN yum -y install nc
 
 RUN yum install -y https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-latest.rpm
 RUN curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg

--- a/CMS_AOD/Dockerfile
+++ b/CMS_AOD/Dockerfile
@@ -2,6 +2,10 @@ FROM cmsopendata/cmssw_5_3_32:latest
 
 USER root
 
+RUN yum clean all
+RUN yum -y update
+RUN yum -y install nc
+
 # Install everything needed to host/run the analysis jobs
 WORKDIR /servicex
 

--- a/CMS_AOD/Dockerfile
+++ b/CMS_AOD/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 RUN yum clean all
 RUN yum -y update
-RUN yum -y install nc
+RUN yum -y install nc jq
 
 # Install everything needed to host/run the analysis jobs
 WORKDIR /servicex

--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -3,7 +3,7 @@
 # FROM daskdev/dask:2.9.0
 FROM continuumio/miniconda3:4.12.0
 
-RUN apt-get update -y && apt-get install gnupg2 -y
+RUN apt-get update -y && apt-get install gnupg2 netcat -y
 
 RUN conda install --yes \
     -c conda-forge \

--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -3,7 +3,7 @@
 # FROM daskdev/dask:2.9.0
 FROM continuumio/miniconda3:4.12.0
 
-RUN apt-get update -y && apt-get install gnupg2 netcat -y
+RUN apt-get update -y && apt-get install gnupg2 netcat jq -y
 
 RUN conda install --yes \
     -c conda-forge \

--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -y && apt-get install gnupg2 netcat jq -y
 RUN conda install --yes \
     -c conda-forge \
     conda-build \
-    xrootd==5.5.5 \
+    xrootd==5.4.3 \
     && conda build purge-all && conda clean -ti
 
 RUN apt update && \

--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -17,8 +17,8 @@ RUN apt update && \
 
 RUN mkdir -p /etc/grid-security/
 RUN export X509_CERT_DIR=/etc/grid-security/certificates/
-RUN wget https://repo.opensciencegrid.org/cadist/1.110NEW/osg-certificates-1.110NEW.tar.gz
-RUN tar -xvf osg-certificates-1.110NEW.tar.gz -C /etc/grid-security/
+RUN wget https://repo.opensciencegrid.org/cadist/1.121IGTFNEW/osg-certificates-1.121IGTFNEW.tar.gz
+RUN tar -xvf osg-certificates-1.121IGTFNEW.tar.gz -C /etc/grid-security/
 
 RUN useradd -ms /bin/bash output -G sudo && passwd -d output
 RUN mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir

--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -y && apt-get install gnupg2 netcat jq -y
 RUN conda install --yes \
     -c conda-forge \
     conda-build \
-    xrootd==5.4.3 \
+    xrootd==5.5.5 \
     && conda build purge-all && conda clean -ti
 
 RUN apt update && \


### PR DESCRIPTION
small changes to make images compatible with the new sidecar from PR https://github.com/ssl-hep/ServiceX/pull/601.
GitHub action only builds images from this branch, and uploads them to my personal dockerhub account.
Next iteration should make develop images built, tagged with both science image tag and servicex release tag, upload them to ssl-hep repo.