### PR TITLE
Updated ATLAS xAOD Science Images

### DIFF
--- a/.github/workflows/atlas.yaml
+++ b/.github/workflows/atlas.yaml
@@ -24,18 +24,26 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
+      - name: Build and push R21
         uses: docker/build-push-action@v3
         with:
           context: ATLASxAOD
           push: true
-          build-args: ANALYSISBASE_TAG=21.2.231 
-          tags: sslhep/servicex_func_adl_xaod_transformer:21.2.231
-      
-      - name: Build and push
+          build-args: ANALYSISBASE_TAG=21.2.266
+          tags: sslhep/servicex_func_adl_xaod_transformer:21.2.266
+
+      - name: Build and push R22
         uses: docker/build-push-action@v3
         with:
           context: ATLASxAOD
           push: true
-          build-args: ANALYSISBASE_TAG=22.2.107
-          tags: sslhep/servicex_func_adl_xaod_transformer:22.2.107
+          build-args: ANALYSISBASE_TAG=22.2.113
+          tags: sslhep/servicex_func_adl_xaod_transformer:22.2.113
+
+      - name: Build and push R24
+        uses: docker/build-push-action@v3
+        with:
+          context: ATLASxAOD
+          push: true
+          build-args: ANALYSISBASE_TAG=24.2.26
+          tags: sslhep/servicex_func_adl_xaod_transformer:24.2.26

--- a/ATLASxAOD/build_r21.sh
+++ b/ATLASxAOD/build_r21.sh
@@ -1,1 +1,1 @@
-docker build -t sslhep/servicex_func_adl_xaod_transformer:21.2.231 --build-arg ANALYSISBASE_TAG=21.2.231 .
+docker build -t sslhep/servicex_func_adl_xaod_transformer:21.2.266 --build-arg ANALYSISBASE_TAG=21.2.266 .

--- a/ATLASxAOD/build_r22.sh
+++ b/ATLASxAOD/build_r22.sh
@@ -1,1 +1,1 @@
-docker build -t sslhep/servicex_func_adl_xaod_transformer:22.2.107 --build-arg ANALYSISBASE_TAG=22.2.107 .
+docker build -t sslhep/servicex_func_adl_xaod_transformer:22.2.113 --build-arg ANALYSISBASE_TAG=22.2.113 .

--- a/ATLASxAOD/build_r24.sh
+++ b/ATLASxAOD/build_r24.sh
@@ -1,0 +1,1 @@
+docker build -t sslhep/servicex_func_adl_xaod_transformer:24.2.26 --build-arg ANALYSISBASE_TAG=24.2.26 .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # ServiceX Science Images
+
+The ServiceX Science Images are built by this package.
+
+## How it works
+
+There are two ways to build things:
+
+* Locally: Use the `build_xxx.sh` files that can be found in the various sub-directories
+* Github CI: This is the official way to build these images. Workflow files can be found in the usual spot, `.github/workflows`
+
+NOTE: If you are updating the tags you need to do it in several places - in the `build_xxx.sh` files and in the YAML CI files (they should track each other). Further, in both places, note there are two places for each tag that need to be updated!


### PR DESCRIPTION
The ATLAS xAOD images get an update:

* Most recent ones for R21 and R22
* Add R24 to the list.

Fixes #3
