### PR TITLE
Update Uproot image to uproot5

### DIFF
--- a/.github/workflows/cms.yaml
+++ b/.github/workflows/cms.yaml
@@ -30,4 +30,4 @@ jobs:
         with:
           context: CMS_AOD
           push: true
-          tags: ivukotic/servicex_func_adl_cms_aod_transformer:cmssw-5-3-32
+          tags: sslhep/servicex_func_adl_cms_aod_transformer:cmssw-5-3-32

--- a/.github/workflows/uproot.yaml
+++ b/.github/workflows/uproot.yaml
@@ -28,4 +28,4 @@ jobs:
         with:
           context: uproot
           push: true
-          tags: ivukotic/servicex_func_adl_uproot_transformer:uproot5
+          tags: sslhep/servicex_func_adl_uproot_transformer:uproot5

--- a/.github/workflows/uproot.yaml
+++ b/.github/workflows/uproot.yaml
@@ -28,4 +28,4 @@ jobs:
         with:
           context: uproot
           push: true
-          tags: ivukotic/servicex_func_adl_uproot_transformer:uproot4 
+          tags: ivukotic/servicex_func_adl_uproot_transformer:uproot5

--- a/uproot/build_uproot4.sh
+++ b/uproot/build_uproot4.sh
@@ -1,1 +1,0 @@
-docker build -t sslhep/servicex_func_adl_uproot_transformer:uproot4 .

--- a/uproot/build_uproot5.sh
+++ b/uproot/build_uproot5.sh
@@ -1,0 +1,1 @@
+docker build -t sslhep/servicex_func_adl_uproot_transformer:uproot5 .

--- a/uproot/requirements.txt
+++ b/uproot/requirements.txt
@@ -1,4 +1,5 @@
-uproot==4.3.7
-awkward==1.10.1
-vector==0.8.4
-pyarrow==9.0.0
+uproot==5.1.2
+awkward==2.5.0
+dask-awkward==2023.11.3
+vector==1.1.1.post1
+pyarrow==14.0.1


### PR DESCRIPTION
Updates to uproot5. This will require an update to the FuncADL Uproot code generator as well (https://github.com/ssl-hep/ServiceX/pull/679).