### PR TITLE
Uproot science image updates

### DIFF
--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -1,7 +1,7 @@
 # based on https://github.com/dask/dask-docker/blob/master/base/Dockerfile
 # but more permissive about image size due to read-only requirement in openshift
 # FROM daskdev/dask:2.9.0
-FROM continuumio/miniconda3:24.5.0
+FROM continuumio/miniconda3:24.5.0-0
 
 RUN apt-get update -y && apt-get install gnupg2 netcat jq -y
 

--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -3,7 +3,7 @@
 # FROM daskdev/dask:2.9.0
 FROM continuumio/miniconda3:24.5.0-0
 
-RUN apt-get update -y && apt-get install gnupg2 netcat jq -y
+RUN apt-get update -y && apt-get install gnupg2 netcat-traditional jq -y
 
 RUN conda install --yes \
     -c conda-forge \

--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -1,14 +1,14 @@
 # based on https://github.com/dask/dask-docker/blob/master/base/Dockerfile
 # but more permissive about image size due to read-only requirement in openshift
 # FROM daskdev/dask:2.9.0
-FROM continuumio/miniconda3:4.12.0
+FROM continuumio/miniconda3:24.5.0
 
 RUN apt-get update -y && apt-get install gnupg2 netcat jq -y
 
 RUN conda install --yes \
     -c conda-forge \
     conda-build \
-    xrootd==5.4.3 \
+    xrootd==5.6.9 \
     && conda build purge-all && conda clean -ti
 
 RUN apt update && \
@@ -17,8 +17,8 @@ RUN apt update && \
 
 RUN mkdir -p /etc/grid-security/
 RUN export X509_CERT_DIR=/etc/grid-security/certificates/
-RUN wget https://repo.opensciencegrid.org/cadist/1.126IGTFNEW/osg-certificates-1.126IGTFNEW.tar.gz
-RUN tar -xvf osg-certificates-1.126IGTFNEW.tar.gz -C /etc/grid-security/
+RUN wget https://repo.opensciencegrid.org/cadist/1.129IGTFNEW/osg-certificates-1.129IGTFNEW.tar.gz
+RUN tar -xvf osg-certificates-1.129IGTFNEW.tar.gz -C /etc/grid-security/
 
 RUN useradd -ms /bin/bash output -G sudo && passwd -d output
 RUN mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir

--- a/uproot/requirements.txt
+++ b/uproot/requirements.txt
@@ -1,4 +1,4 @@
-uproot==5.3.8
+uproot==5.3.9
 awkward==2.6.6
 dask-awkward==2024.6.0
 vector==1.4.1

--- a/uproot/requirements.txt
+++ b/uproot/requirements.txt
@@ -1,5 +1,5 @@
-uproot==5.1.2
-awkward==2.5.0
-dask-awkward==2023.11.3
-vector==1.1.1.post1
-pyarrow==14.0.1
+uproot==5.3.8
+awkward==2.6.6
+dask-awkward==2024.6.0
+vector==1.4.1
+pyarrow==16.1.0


### PR DESCRIPTION
uproot 5.1.2 -> 5.3.9 (this is actually quite important since it should fix an occasional bug we see in SXLite reading directly from dCache)
awkward 2.5.0 -> 2.6.6
dask-awkward 2023.11.3 -> 2024.6.0
vector 1.1.1.post1 -> 1.4.1
pyarrow 14.0.1 -> 16.1.0
xrootd 5.4.3 -> 5.6.9
miniconda3 base image 4.12.0 -> 24.5.0