### PR TITLE
Update ATLAS images to OSG 3.6

### DIFF
--- a/ATLASxAOD/Dockerfile
+++ b/ATLASxAOD/Dockerfile
@@ -8,7 +8,7 @@ RUN yum clean all
 RUN yum -y update
 RUN yum -y install nc jq
 
-RUN yum install -y https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-latest.rpm
+RUN yum install -y https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el7-release-latest.rpm
 RUN curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg
 RUN curl -s -o /etc/yum.repos.d/wlcg-centos7.repo http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo;
 RUN yum install -y xrootd-client xrootd \


### PR DESCRIPTION
OSG 3.5 RPMs have been yanked and the old Dockerfile will fail to build in the future. Have not tested functionality of  image based on OSG 3.6 though.