### PR TITLE
Try a R25 build for ATLASxAOD

### DIFF
--- a/.github/workflows/atlas.yaml
+++ b/.github/workflows/atlas.yaml
@@ -22,20 +22,35 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # - name: Build and push R21
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     context: ATLASxAOD
-      #     push: ${{ github.ref == 'refs/heads/main' }}
-      #     build-args: ANALYSISBASE_TAG=21.2.231 
-      #     tags: sslhep/servicex_func_adl_xaod_transformer:21.2.231
-      #     platforms: linux/amd64
+      - name: Build and push R21
+        uses: docker/build-push-action@v3
+        with:
+          context: ATLASxAOD
+          push: ${{ github.ref == 'refs/heads/main' }}
+          build-args: |
+            ANALYSISBASE_TAG=21.2.231
+            EL=7
+          tags: sslhep/servicex_func_adl_xaod_transformer:21.2.231
+          platforms: linux/amd64
       
       - name: Build and push R22
         uses: docker/build-push-action@v3
         with:
           context: ATLASxAOD
           push: ${{ github.ref == 'refs/heads/main' }}
-          build-args: ANALYSISBASE_TAG=25.2.38
-          tags: sslhep/servicex_func_adl_xaod_transformer:25.2.38
+          build-args: |
+            ANALYSISBASE_TAG=22.2.107
+            EL=7
+          tags: sslhep/servicex_func_adl_xaod_transformer:22.2.107
+          platforms: linux/amd64
+
+      - name: Build and push R25
+        uses: docker/build-push-action@v3
+        with:
+          context: ATLASxAOD
+          push: ${{ github.ref == 'refs/heads/main' }}
+          build-args: |
+            ANALYSISBASE_TAG=25.2.41
+            EL=9
+          tags: sslhep/servicex_func_adl_xaod_transformer:25.2.41
           platforms: linux/amd64

--- a/.github/workflows/atlas.yaml
+++ b/.github/workflows/atlas.yaml
@@ -22,20 +22,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push R21
-        uses: docker/build-push-action@v3
-        with:
-          context: ATLASxAOD
-          push: ${{ github.ref == 'refs/heads/main' }}
-          build-args: ANALYSISBASE_TAG=21.2.231 
-          tags: sslhep/servicex_func_adl_xaod_transformer:21.2.231
-          platforms: linux/amd64
+      # - name: Build and push R21
+      #   uses: docker/build-push-action@v3
+      #   with:
+      #     context: ATLASxAOD
+      #     push: ${{ github.ref == 'refs/heads/main' }}
+      #     build-args: ANALYSISBASE_TAG=21.2.231 
+      #     tags: sslhep/servicex_func_adl_xaod_transformer:21.2.231
+      #     platforms: linux/amd64
       
       - name: Build and push R22
         uses: docker/build-push-action@v3
         with:
           context: ATLASxAOD
           push: ${{ github.ref == 'refs/heads/main' }}
-          build-args: ANALYSISBASE_TAG=22.2.107
-          tags: sslhep/servicex_func_adl_xaod_transformer:22.2.107
+          build-args: ANALYSISBASE_TAG=25.2.38
+          tags: sslhep/servicex_func_adl_xaod_transformer:25.2.38
           platforms: linux/amd64

--- a/ATLASxAOD/Dockerfile
+++ b/ATLASxAOD/Dockerfile
@@ -1,4 +1,4 @@
-ARG ANALYSISBASE_TAG=21.2.231
+ARG ANALYSISBASE_TAG=25.2.38
 
 FROM atlas/analysisbase:$ANALYSISBASE_TAG
 FROM gitlab-registry.cern.ch/atlas/athena/analysisbase:$ANALYSISBASE_TAG
@@ -6,8 +6,8 @@ USER root
 
 RUN sed -i -e 's/linuxsoft.cern.ch/archives.fedoraproject.org\/pub\/archive/g' /etc/yum.repos.d/epel.repo
 RUN curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg https://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg \
-    && curl -s -o /etc/yum.repos.d/wlcg-centos7.repo http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo
-RUN yum install -y https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el7-release-latest.rpm \
+    && curl -s -o /etc/yum.repos.d/wlcg-el9.repo http://linuxsoft.cern.ch/wlcg/wlcg-el9.repo
+RUN yum install -y https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el9-release-latest.rpm \
     && yum -y update \
     && yum -y install nc jq \
     && yum install -y xrootd-client xrootd \

--- a/ATLASxAOD/Dockerfile
+++ b/ATLASxAOD/Dockerfile
@@ -1,14 +1,27 @@
 ARG ANALYSISBASE_TAG=25.2.38
-ARG EL=9
 
 FROM atlas/analysisbase:$ANALYSISBASE_TAG
 FROM gitlab-registry.cern.ch/atlas/athena/analysisbase:$ANALYSISBASE_TAG
+ARG EL=9
+
 USER root
 
-RUN [ $EL == "7" ] && sed -i -e 's/linuxsoft.cern.ch/archives.fedoraproject.org\/pub\/archive/g' /etc/yum.repos.d/epel.repo
+RUN if [[ $EL == 7 ]] ; then { \
+        sed -i -e 's/linuxsoft.cern.ch/archives.fedoraproject.org\/pub\/archive/g' /etc/yum.repos.d/epel.repo ; \
+    } ; else { \
+        dnf install -y epel-release ; \
+    } ; fi
 RUN curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg https://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg \
-    && curl -s -o /etc/yum.repos.d/wlcg-el${EL}.repo http://linuxsoft.cern.ch/wlcg/wlcg-el${EL}.repo
-RUN yum install -y https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el${EL}-release-latest.rpm \
+    && if [[ $EL == 7 ]] ; then { \
+      curl -s -o /etc/yum.repos.d/wlcg-centos7.repo http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo ; \
+    } ; else { \
+        curl -s -o /etc/yum.repos.d/wlcg-el${EL}.repo http://linuxsoft.cern.ch/wlcg/wlcg-el${EL}.repo ; \
+    } ; fi
+RUN if [[ $EL == 7 ]] ; then { \
+        yum install -y https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el${EL}-release-latest.rpm  ; \
+    } ; else { \
+        yum install -y https://repo.osg-htc.org/osg/24-main/osg-24-main-el9-release-latest.rpm ; \
+    } ; fi \
     && yum -y update \
     && yum -y install nc jq \
     && yum install -y xrootd-client xrootd \
@@ -29,6 +42,6 @@ ENV INSTANCE="atlas_xaod_cpp_transformer"
 ENV DESC="ATLAS xAOD CPP Transformer"
 
 ENV X509_USER_PROXY=/tmp/grid-security/x509up
-ENV X509_CERT_DIR /etc/grid-security/certificates
+ENV X509_CERT_DIR=/etc/grid-security/certificates
 
 WORKDIR /home/atlas

--- a/ATLASxAOD/Dockerfile
+++ b/ATLASxAOD/Dockerfile
@@ -1,13 +1,14 @@
 ARG ANALYSISBASE_TAG=25.2.38
+ARG EL=9
 
 FROM atlas/analysisbase:$ANALYSISBASE_TAG
 FROM gitlab-registry.cern.ch/atlas/athena/analysisbase:$ANALYSISBASE_TAG
 USER root
 
-RUN sed -i -e 's/linuxsoft.cern.ch/archives.fedoraproject.org\/pub\/archive/g' /etc/yum.repos.d/epel.repo
+RUN [ $EL == "7" ] && sed -i -e 's/linuxsoft.cern.ch/archives.fedoraproject.org\/pub\/archive/g' /etc/yum.repos.d/epel.repo
 RUN curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg https://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg \
-    && curl -s -o /etc/yum.repos.d/wlcg-el9.repo http://linuxsoft.cern.ch/wlcg/wlcg-el9.repo
-RUN yum install -y https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el9-release-latest.rpm \
+    && curl -s -o /etc/yum.repos.d/wlcg-el${EL}.repo http://linuxsoft.cern.ch/wlcg/wlcg-el${EL}.repo
+RUN yum install -y https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el${EL}-release-latest.rpm \
     && yum -y update \
     && yum -y install nc jq \
     && yum install -y xrootd-client xrootd \

--- a/ATLASxAOD/build_r21.sh
+++ b/ATLASxAOD/build_r21.sh
@@ -1,1 +1,2 @@
-docker build -t sslhep/servicex_func_adl_xaod_transformer:21.2.231 --build-arg ANALYSISBASE_TAG=21.2.231 .
+docker build -t sslhep/servicex_func_adl_xaod_transformer:21.2.231 --build-arg ANALYSISBASE_TAG=21.2.231 \
+    --build-arg EL=7 .

--- a/ATLASxAOD/build_r22.sh
+++ b/ATLASxAOD/build_r22.sh
@@ -1,1 +1,1 @@
-docker build -t sslhep/servicex_func_adl_xaod_transformer:22.2.107 --build-arg ANALYSISBASE_TAG=22.2.107 .
+docker build -t sslhep/servicex_func_adl_xaod_transformer:25.2.38 --build-arg ANALYSISBASE_TAG=25.2.38 .

--- a/ATLASxAOD/build_r22.sh
+++ b/ATLASxAOD/build_r22.sh
@@ -1,1 +1,2 @@
-docker build -t sslhep/servicex_func_adl_xaod_transformer:25.2.38 --build-arg ANALYSISBASE_TAG=25.2.38 .
+docker build -t sslhep/servicex_func_adl_xaod_transformer:22.2.107 --build-arg ANALYSISBASE_TAG=22.2.107 \
+    --build-arg EL=7 .

--- a/ATLASxAOD/build_r25.sh
+++ b/ATLASxAOD/build_r25.sh
@@ -1,0 +1,2 @@
+docker build -t sslhep/servicex_func_adl_xaod_transformer:25.2.41 --build-arg ANALYSISBASE_TAG=25.2.41 \
+    --build-arg EL=9 .


### PR DESCRIPTION
Add a release 25 version of the ATLAS xAOD science image. We now build three images. The Dockerfile needs to be modified to support both CentOS 7 and AlmaLinux 9 containers.