### PR TITLE
Update TopCP science image

### DIFF
--- a/TopCP/Dockerfile
+++ b/TopCP/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /
 RUN --mount=type=secret,id=GIT_KEY,env=GIT_KEY\
     git clone https://${GIT_KEY}@gitlab.cern.ch/atlas-physics/beauty/common-tools/TopCPToolkit.git
 WORKDIR /TopCPToolkit
-RUN   git fetch -a && git checkout bphy-algorithms
+RUN   git fetch -a && git checkout 06949e9ffd014e4845a4ccac88e49e1e837b2b49
 
 # Make /TopCPToolkit/run directory where runTop_el.py is executed
 RUN mkdir -p run

--- a/TopCP/Dockerfile
+++ b/TopCP/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
 
 # This is the default AnalysisBase version
-ARG ANALYSIS_BASE_VERSION=25.2.38 
+ARG ANALYSIS_BASE_VERSION=25.2.45
 FROM gitlab-registry.cern.ch/atlas/athena/analysisbase:${ANALYSIS_BASE_VERSION} AS base
-ARG TOPCPTOOLKIT_TAG=2.16.1
+ARG TOPCPTOOLKIT_TAG=2.17.0
 
 SHELL [ "/bin/bash", "-c" ]
 
@@ -16,9 +16,9 @@ RUN yum install -y nc
 # download TopCPToolkit repo
 WORKDIR /
 RUN --mount=type=secret,id=GIT_KEY,env=GIT_KEY\
-    git clone https://${GIT_KEY}@gitlab.cern.ch/atlasphys-top/reco/TopCPToolkit.git
+    git clone https://${GIT_KEY}@gitlab.cern.ch/atlas-physics/beauty/common-tools/TopCPToolkit.git
 WORKDIR /TopCPToolkit
-RUN   git fetch -a && git checkout tags/v${TOPCPTOOLKIT_TAG}
+RUN   git fetch -a && git checkout bphy-algorithms
 
 # Make /TopCPToolkit/run directory where runTop_el.py is executed
 RUN mkdir -p run

--- a/TopCP/README.md
+++ b/TopCP/README.md
@@ -1,3 +1,3 @@
 Use this command to build:
 
-GIT_KEY='<git_key>' docker buildx build --secret id=GIT_KEY,env=GIT_KEY --build-arg TOPCPTOOLKIT_TAG="<tag (2.16.1 by default)>" --build-arg ANALYSIS_BASE_VERSION="<analysis base version (25.2.38 by default)>" .
+GIT_KEY='<git_key>' docker buildx build --secret id=GIT_KEY,env=GIT_KEY --build-arg TOPCPTOOLKIT_TAG="<tag (2.17.0 by default)>" --build-arg ANALYSIS_BASE_VERSION="<analysis base version (25.2.45 by default)>" .

--- a/TopCP/README.md
+++ b/TopCP/README.md
@@ -1,3 +1,6 @@
-Use this command to build:
+### Docker build command:
 
-GIT_KEY='<git_key>' docker buildx build --secret id=GIT_KEY,env=GIT_KEY --build-arg TOPCPTOOLKIT_TAG="<tag (2.17.0 by default)>" --build-arg ANALYSIS_BASE_VERSION="<analysis base version (25.2.45 by default)>" .
+```
+GIT_KEY='<git_key>' docker buildx build --platform linux/amd64,linux/arm64 --secret id=GIT_KEY,env=GIT_KEY --build-arg TOPCPTOOLKIT_TAG="<tag (2.17.0 by default)>" --build-arg ANALYSIS_BASE_VERSION="<analysis base version (25.2.45 by default)>" 
+servicex_topcp_transformer:develop .
+```


### PR DESCRIPTION
- Latest AnalysisBase (25.2.45) and TopCPToolkit version (2.17.0) as of March 19, 2025
- Build TopCPToolkit framework with BLS algorithms from the [BLS Gitlab repo](https://gitlab.cern.ch/atlas-physics/beauty/common-tools/TopCPToolkit/-/tree/bphy-algorithms)