### PR TITLE
Bump the certificate version for uproot properly

### DIFF
--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -2,7 +2,7 @@
 # but more permissive about image size due to read-only requirement in openshift
 # FROM daskdev/dask:2.9.0
 FROM continuumio/miniconda3:24.5.0-0
-ARG CERTIFICATE_VERSION=1.135GTFNEW
+ARG CERTIFICATE_VERSION=1.135IGTFNEW
 
 RUN apt-get update -y && apt-get install gnupg2 netcat-traditional jq -y
 


### PR DESCRIPTION
version 1.135IGTFNEW; last accidental commit straight to main had a typo