### PR TITLE
Replace miniconda3 with miniforge3

### DIFF
--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -1,7 +1,7 @@
 # based on https://github.com/dask/dask-docker/blob/master/base/Dockerfile
 # but more permissive about image size due to read-only requirement in openshift
 # FROM daskdev/dask:2.9.0
-FROM continuumio/miniconda3:24.5.0-0
+FROM condaforge/miniforge3:24.11.3-2
 ARG CERTIFICATE_VERSION=1.136IGTFNEW
 
 RUN apt-get update -y && apt-get install gnupg2 netcat-traditional jq -y


### PR DESCRIPTION
Same org replacement of #34 

From @holzman:
* Works out of the box with any user (not just root)
* Avoids any problematic Ananconda, LLC license issues
