### PR TITLE
Update uproot to 5.6.3

### DIFF
--- a/uproot/requirements.lock
+++ b/uproot/requirements.lock
@@ -798,9 +798,9 @@ typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
     # via dask-awkward
-uproot==5.6.2 \
-    --hash=sha256:18f4d3fc0cccc7234297b9c809cf80ada8dff31cd8d4feba4bc4132c5312b511 \
-    --hash=sha256:e5cf556cc418a835f8a4177695d662c99d2b987684e1319b022115d8cb43da47
+uproot==5.6.3 \
+    --hash=sha256:47f2aefcdcae503c9a21900381ac42a7bc3274cd0c52cd0686700d282ad0f46b \
+    --hash=sha256:a4c178edb828812d08f19c0e36fedca189946b796fc12eecb1394b091179ad05
     # via -r requirements.txt
 urllib3==2.2.3 \
     --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \

--- a/uproot/requirements.txt
+++ b/uproot/requirements.txt
@@ -1,4 +1,4 @@
-uproot[xrootd,http,s3]==5.6.2
+uproot[xrootd,http,s3]==5.6.3
 awkward==2.8.3
 dask-awkward==2025.3.0
 vector==1.6.1


### PR DESCRIPTION
Includes better RNTuple support, requested by CMS https://github.com/scikit-hep/uproot5/releases/tag/v5.6.3