### PR TITLE
Update ATLAS xAOD release 25 to 25.2.89

### DIFF
--- a/.github/workflows/atlas.yaml
+++ b/.github/workflows/atlas.yaml
@@ -28,9 +28,9 @@ jobs:
           context: ATLASxAOD
           push: ${{ github.ref == 'refs/heads/main' }}
           build-args: |
-            ANALYSISBASE_TAG=25.2.80
+            ANALYSISBASE_TAG=25.2.89
             EL=9
-          tags: sslhep/servicex_func_adl_xaod_transformer:25.2.80
+          tags: sslhep/servicex_func_adl_xaod_transformer:25.2.89
           platforms: linux/amd64,linux/arm64
 
       - name: Build and push R22

--- a/ATLASxAOD/Dockerfile
+++ b/ATLASxAOD/Dockerfile
@@ -1,4 +1,4 @@
-ARG ANALYSISBASE_TAG=25.2.38
+ARG ANALYSISBASE_TAG=25.2.89
 
 FROM atlas/analysisbase:$ANALYSISBASE_TAG
 FROM gitlab-registry.cern.ch/atlas/athena/analysisbase:$ANALYSISBASE_TAG

--- a/ATLASxAOD/README.md
+++ b/ATLASxAOD/README.md
@@ -19,3 +19,8 @@ The release 25 image tracks the latest published `25.2.x` `analysisbase` tag fro
 - The Dockerfile references the CERN registry directly, so the tag update should always be based on the registry contents, not on the local default in the file.
 - Keep the build script and workflow in sync. They are intentionally redundant so local builds and CI produce the same release tag.
 - Full AnalysisBase release information is available behind CERN ATLAS authentication here: https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/AnalysisRelease
+
+## Testing
+
+After building the image, run `docker run --rm <image> sh -lc '. ./release_setup.sh'`.
+The command should print two paths. The second path should contain the release tag you built against, for example `25.2.89` for release 25.

--- a/ATLASxAOD/README.md
+++ b/ATLASxAOD/README.md
@@ -1,0 +1,20 @@
+# ATLAS xAOD Science Images
+
+This directory contains the build inputs for the ATLAS xAOD transformer science images.
+
+## Current release
+
+The release 25 image tracks the latest published `25.2.x` `analysisbase` tag from `gitlab-registry.cern.ch/atlas/athena/analysisbase`.
+
+## How to update release 25
+
+1. Query the registry for the newest `25.2.x` tag.
+1. Update `ATLASxAOD/Dockerfile` so `ANALYSISBASE_TAG` matches that tag.
+1. Update `ATLASxAOD/build_r25.sh` to use the same tag in both the image tag and the build arg.
+1. Update `.github/workflows/atlas.yaml` so the R25 build uses the same tag in both the build arg and the pushed image tag.
+1. Rebuild or let CI rebuild the image, then verify the pushed tag matches the base image version.
+
+## Notes
+
+- The Dockerfile references the CERN registry directly, so the tag update should always be based on the registry contents, not on the local default in the file.
+- Keep the build script and workflow in sync. They are intentionally redundant so local builds and CI produce the same release tag.

--- a/ATLASxAOD/README.md
+++ b/ATLASxAOD/README.md
@@ -18,3 +18,4 @@ The release 25 image tracks the latest published `25.2.x` `analysisbase` tag fro
 
 - The Dockerfile references the CERN registry directly, so the tag update should always be based on the registry contents, not on the local default in the file.
 - Keep the build script and workflow in sync. They are intentionally redundant so local builds and CI produce the same release tag.
+- Full AnalysisBase release information is available behind CERN ATLAS authentication here: https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/AnalysisRelease

--- a/ATLASxAOD/build_r25.sh
+++ b/ATLASxAOD/build_r25.sh
@@ -1,2 +1,2 @@
-docker build -t sslhep/servicex_func_adl_xaod_transformer:25.2.80 --build-arg ANALYSISBASE_TAG=25.2.80 \
+docker build -t sslhep/servicex_func_adl_xaod_transformer:25.2.89 --build-arg ANALYSISBASE_TAG=25.2.89 \
     --build-arg EL=9 .

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ To update the ATLASxAOD version for a specific release, the version string must 
 
 - 2 places in `ATLASxAOD/build_r25.sh`
 - 2 places in `.github/workflows/atlas.yaml` (the `ANALYSISBASE_TAG` variable and the `sslhep/servicex_func_adl_xaod_transformer` image tag)
+- `ATLASxAOD/README.md` documents the update procedure for this image family


### PR DESCRIPTION
PR to update the ATLAS xAOD release 25 science image to the latest published AnalysisBase tag, `25.2.89`. Also include README.md that records what we should do to bump the image and test it. Hopefully this is good enough so next time anyone (or a LLM!) can read this and just go through it.

Changes:
- bump `ATLASxAOD/Dockerfile` to `25.2.89`
- align `ATLASxAOD/build_r25.sh` and `.github/workflows/atlas.yaml`
- add `ATLASxAOD/README.md` with the release-update and testing procedure and the CERN AnalysisBase reference.

Note: the update was verified against the CERN registry tag list for `atlas/athena/analysisbase`.