### PR TITLE
Switch CA bundle from IGTF to OSG (IGTF + LetsEncrypt)

### DIFF
--- a/root/Dockerfile
+++ b/root/Dockerfile
@@ -5,7 +5,7 @@ ARG ROOTVER=6.32.04
 ARG PLATFORM=ubuntu24.04
 FROM rootproject/root:${ROOTVER}-${PLATFORM}
 # This is the version of the OSG certificates to be downloaded (same meaning as for the uproot container)
-ARG CERTIFICATE_VERSION=1.140IGTFNEW
+ARG CERTIFICATE_VERSION=1.140NEW
 
 RUN apt update -y && apt upgrade -y && \
     apt-get install gnupg2 netcat-traditional jq sudo xrootd-client -y

--- a/uproot/Dockerfile
+++ b/uproot/Dockerfile
@@ -2,7 +2,7 @@
 # but more permissive about image size due to read-only requirement in openshift
 # FROM daskdev/dask:2.9.0
 FROM condaforge/miniforge3:24.11.3-2
-ARG CERTIFICATE_VERSION=1.140IGTFNEW
+ARG CERTIFICATE_VERSION=1.140NEW
 
 RUN apt-get update -y && apt-get install gnupg2 netcat-traditional jq -y
 


### PR DESCRIPTION
This would simplify our lives with the ServiceX work at Nebraska's CMS analysis facility, and allow ServiceX containers to retrieve XRootD data from servers with LetsEncrypt certs.

Getting IGTF certificates has some challenges for our environment. We can readily get IGTF certificates for our institutional (unl.edu) domain. But for our k8s cluster, we're using a separate domain name to allow dynamic DNS. Allowing LetsEncrypt would make cert management easier.